### PR TITLE
Blockmesh: Restart the running blockmesh-cli-container to use the new binary

### DIFF
--- a/BlockMesh/install.sh
+++ b/BlockMesh/install.sh
@@ -62,5 +62,6 @@ if ! docker ps --filter "name=blockmesh-cli-container" | grep -q 'blockmesh-cli-
         --workdir /app \
         ubuntu:22.04 ./blockmesh-cli --email "$email" --password "$password"
 else
-    echo "BlockMesh CLI container is already running, skipping..."
+    echo "BlockMesh CLI container is already running, restarting to use the new binary"
+    docker restart blockmesh-cli-container
 fi


### PR DESCRIPTION
The blockmesh-cli-container can be restarted without stopping the running container, and it will use the new binary.